### PR TITLE
Add a benchmark for counting real grab cost

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -38,4 +38,12 @@ target_link_libraries(benchmark_target_fps
 )
 add_dependencies(benchmark_target_fps DXCam)
 
+# Benchmark: real_grab_cost
+add_executable(real_grab_cost src/real_grab_cost.cpp)
+target_link_libraries(real_grab_cost
+        DXCam
+        ${OpenCV_LIBS}
+)
+add_dependencies(real_grab_cost DXCam)
+
 message(STATUS "Configuring benchmark - done")

--- a/benchmark/src/real_grab_cost.cpp
+++ b/benchmark/src/real_grab_cost.cpp
@@ -1,0 +1,52 @@
+
+#include <chrono>
+#include <cstdio>
+#include <string>
+
+#include "dxcam.h"
+
+// params
+const std::string TITLE = "[Benchmark] real_grab_cost";
+const auto REGION = DXCam::Region{0, 0, 1920, 1080};
+const int TOTAL_FRAMES = 100;
+
+double bench(const std::shared_ptr<DXCam::DXCamera>& camera) {
+    double total_grab_cost = 0;
+    cv::Mat prev_frame;
+
+    for (int i = 0; i < TOTAL_FRAMES;) {
+        const auto begin_grab = std::chrono::steady_clock::now();
+        auto frame = camera->grab();
+        const auto end_grab = std::chrono::steady_clock::now();
+
+        if (prev_frame.empty()) {
+            frame.copyTo(prev_frame);
+            total_grab_cost += std::chrono::duration<double>(end_grab - begin_grab).count();
+        } else {
+            bool is_identical = (sum(frame != prev_frame) == cv::Scalar(0, 0, 0, 0));
+            if (!is_identical) {
+                total_grab_cost += std::chrono::duration<double>(end_grab - begin_grab).count();
+                frame.copyTo(prev_frame);
+                i++;
+            }
+        }
+    }
+
+    return total_grab_cost;
+}
+
+int main() {
+    // init
+    auto camera = DXCam::create(REGION);
+
+    // benchmark
+    double total_grab_cost = std::numeric_limits<double>::max();
+    total_grab_cost = std::min(total_grab_cost, bench(camera));
+
+
+    // result
+    const auto average_cost = total_grab_cost / TOTAL_FRAMES * 1000;
+    printf("%s: %d loops, average grab cost %.3lf ms\n", TITLE.c_str(), TOTAL_FRAMES, average_cost);
+
+    return 0;
+}


### PR DESCRIPTION
If a new frame doesn't arrive, the grab method will immediately return the previous frame, without actually doing a grab.  
This benchmark counts the time cost on the grab operation when a new frame arrives.